### PR TITLE
Rename material design icon, fix documentation URL

### DIFF
--- a/custom_components/hisense_tv/helper.py
+++ b/custom_components/hisense_tv/helper.py
@@ -35,7 +35,7 @@ class HisenseTvBase(object):
         self._mqtt_out = mqtt_out or ""
         self._mac = mac
         self._unique_id = uid
-        self._icon = "mdi:television-clear"
+        self._icon = "mdi:television-shimmer"
         self._subscriptions = {
             "tvsleep": lambda: None,
             "state": lambda: None,

--- a/custom_components/hisense_tv/manifest.json
+++ b/custom_components/hisense_tv/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "hisense_tv",
     "name": "Hisense TV MQTT Bridge",
-    "version": "21.4.9",
+    "version": "21.10.16",
     "documentation": "https://github.com/sehaas/ha_hisense_tv",
     "dependencies": ["mqtt"],
     "codeowners": [

--- a/custom_components/hisense_tv/manifest.json
+++ b/custom_components/hisense_tv/manifest.json
@@ -1,8 +1,8 @@
 {
     "domain": "hisense_tv",
     "name": "Hisense TV MQTT Bridge",
-    "version": "21.4.8",
-    "documentation": "https://github.com/sehaas/ha_hisense",
+    "version": "21.4.9",
+    "documentation": "https://github.com/sehaas/ha_hisense_tv",
     "dependencies": ["mqtt"],
     "codeowners": [
       "@sehaas"


### PR DESCRIPTION
Thanks for this project!
I got log errors like:
```2021-10-15 07:37:21 WARNING (MainThread) [frontend.js.latest.202110071] Icon mdi:television-clean was renamed to mdi:television-shimmer, please change your config, it will be removed in version 2021.12. ```

So, I have renamed the icon.
I also got a 404 when trying to access the docs from HACS, so I have corrected this as well.

I am participating in #hacktoberfest, so I would appreciate if you could add the 'hacktoberfest-accepted' label.

Thanks 👍 