### PR TITLE
Poll media player via actions/gettvstate

### DIFF
--- a/custom_components/hisense_tv/media_player.py
+++ b/custom_components/hisense_tv/media_player.py
@@ -162,7 +162,7 @@ class HisenseTvEntity(MediaPlayerEntity, HisenseTvBase):
     @property
     def should_poll(self):
         """Poll for non media_player updates."""
-        return False
+        return True
 
     @property
     def media_content_type(self):

--- a/custom_components/hisense_tv/media_player.py
+++ b/custom_components/hisense_tv/media_player.py
@@ -158,6 +158,8 @@ class HisenseTvEntity(MediaPlayerEntity, HisenseTvBase):
         self._channel_num = None
         self._channel_infos = {}
         self._app_list = {}
+        self._last_trigger = dt_util.utcnow()
+        self._force_trigger = False
 
     @property
     def should_poll(self):

--- a/custom_components/hisense_tv/media_player.py
+++ b/custom_components/hisense_tv/media_player.py
@@ -1,4 +1,5 @@
 """Hisense TV media player entity."""
+from datetime import timedelta
 import asyncio
 import json
 from json.decoder import JSONDecodeError

--- a/custom_components/hisense_tv/media_player.py
+++ b/custom_components/hisense_tv/media_player.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 import wakeonlan
 
 from homeassistant.components import mqtt
+from homeassistant.util import dt as dt_util
 from homeassistant.components.media_player import (
     DEVICE_CLASS_TV,
     PLATFORM_SCHEMA,


### PR DESCRIPTION
The media player entity state doesn't update when the TV settings are changed outside of Home Assistant, e.g. via the remote control. This PR adds polling of actions/gettvstate to refresh the media player entity state.

Appears to work ok for my setup but I haven't done any HA custom components before so it would be great if someone else could test it. In particular I am unsure about the topic /remoteapp/tv/ui_service/AutoHTPC/actions/gettvstate because my older Hisense doesn't need any of the MAC_ADDRESS$normal stuff in the message topic.

Note that this may be a fix for the similar issue raised in https://github.com/sehaas/ha_hisense_tv/issues/44
